### PR TITLE
Add test for ngcc

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -25,6 +25,7 @@ ts_library(
     tsconfig = ":tsconfig",
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngcc",
         "//packages/compiler-cli/src/ngtsc/annotations",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/transform",

--- a/packages/compiler-cli/src/ngcc/BUILD.bazel
+++ b/packages/compiler-cli/src/ngcc/BUILD.bazel
@@ -4,23 +4,14 @@ load("//tools:defaults.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
-    name = "test_lib",
-    testonly = 1,
+    name = "ngcc",
     srcs = glob([
+        "*.ts",
         "**/*.ts",
     ]),
     deps = [
         "//packages:types",
+        "//packages/compiler-cli/src/ngtsc/host",
         "//packages/compiler-cli/src/ngtsc/metadata",
-        "//packages/compiler-cli/src/ngtsc/testing",
-    ],
-)
-
-jasmine_node_test(
-    name = "test",
-    bootstrap = ["angular/tools/testing/init_node_no_angular_spec.js"],
-    deps = [
-        ":test_lib",
-        "//tools/testing:node_no_angular",
     ],
 )

--- a/packages/compiler-cli/test/ngcc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngcc/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
     deps = [
         "//packages/compiler",
         "//packages/compiler-cli",
+        "//packages/compiler-cli/src/ngcc",
         "//packages/compiler-cli/test:test_utils",
     ],
 )
@@ -18,7 +19,8 @@ jasmine_node_test(
     name = "ngcc",
     bootstrap = ["angular/tools/testing/init_node_no_angular_spec.js"],
     data = [
-        "//packages/compiler-cli/test/ngcc/fake_core:npm_package",
+      "//packages/core:npm_package",
+      "//packages/common:npm_package",
     ],
     deps = [
         ":ngcc_lib",

--- a/packages/compiler-cli/test/ngcc/ngcc_spec.ts
+++ b/packages/compiler-cli/test/ngcc/ngcc_spec.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {mainNgcc} from '../../src/ngcc/src/main';
+
+import {TestSupport, isInBazel, setup} from '../test_support';
+
+function setupNodeModules(support: TestSupport): void {
+  const corePath = path.join(process.env.TEST_SRCDIR, 'angular/packages/core/npm_package');
+  const commonPath = path.join(process.env.TEST_SRCDIR, 'angular/packages/common/npm_package');
+
+  const nodeModulesPath = path.join(support.basePath, 'node_modules');
+  const angularCoreDirectory = path.join(nodeModulesPath, '@angular/core');
+  const angularCommonDirectory = path.join(nodeModulesPath, '@angular/common');
+
+  // fs.symlinkSync(corePath, angularCoreDirectory);
+  // fs.symlinkSync(commonPath, angularCommonDirectory);
+}
+
+describe('ngcc behavioral tests', () => {
+  if (!isInBazel()) {
+    // These tests should be excluded from the non-Bazel build.
+    return;
+  }
+
+  let basePath: string;
+  let outDir: string;
+  let write: (fileName: string, content: string) => void;
+  let errorSpy: jasmine.Spy&((s: string) => void);
+
+  function shouldExist(fileName: string) {
+    if (!fs.existsSync(path.resolve(outDir, fileName))) {
+      throw new Error(`Expected ${fileName} to be emitted (outDir: ${outDir})`);
+    }
+  }
+
+  function shouldNotExist(fileName: string) {
+    if (fs.existsSync(path.resolve(outDir, fileName))) {
+      throw new Error(`Did not expect ${fileName} to be emitted (outDir: ${outDir})`);
+    }
+  }
+
+  function getContents(fileName: string): string {
+    shouldExist(fileName);
+    const modulePath = path.resolve(outDir, fileName);
+    return fs.readFileSync(modulePath, 'utf8');
+  }
+
+  function writeConfig(
+      tsconfig: string =
+          '{"extends": "./tsconfig-base.json", "angularCompilerOptions": {"enableIvy": "ngtsc"}}') {
+    write('tsconfig.json', tsconfig);
+  }
+
+  beforeEach(() => {
+    errorSpy = jasmine.createSpy('consoleError').and.callFake(console.error);
+    const support = setup();
+    basePath = support.basePath;
+    outDir = path.join(basePath, 'built');
+    process.chdir(basePath);
+    write = (fileName: string, content: string) => { support.write(fileName, content); };
+
+    setupNodeModules(support);
+  });
+
+  it('should run ngcc without errors', () => {
+    const nodeModulesPath = path.join(basePath, 'node_modules');
+    console.error(nodeModulesPath);
+    const commonPath = path.join(nodeModulesPath, '@angular/common');
+    const exitCode = mainNgcc([commonPath]);
+
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR implements a Bazel test `ngcc_spec.ts` which verifies functionality of `ngcc`.